### PR TITLE
Null checks for Raw json in TokenResponse

### DIFF
--- a/source/Client/TokenResponse.cs
+++ b/source/Client/TokenResponse.cs
@@ -115,7 +115,7 @@ namespace Thinktecture.IdentityModel.Client
         protected virtual string GetStringOrNull(string name)
         {
             JToken value;
-            if (Json.TryGetValue(name, StringComparison.OrdinalIgnoreCase, out value))
+            if (Json != null && Json.TryGetValue(name, StringComparison.OrdinalIgnoreCase, out value))
             {
                 return value.ToString();
             }
@@ -126,7 +126,7 @@ namespace Thinktecture.IdentityModel.Client
         protected virtual long GetLongOrNull(string name)
         {
             JToken value;
-            if (Json.TryGetValue(name, out value))
+            if (Json != null && Json.TryGetValue(name, out value))
             {
                 long longValue = 0;
                 if (long.TryParse(value.ToString(), out longValue))


### PR DESCRIPTION
If I get a HTTP 500 from identity server due to me screwing up the configuration, the TokenResponse object throws NullReferenceExceptions on the ```Error``` property due to the raw Json not being set. 